### PR TITLE
Output UTF8 instead of binary, create a temp text file in case user console doesn't support UTF8

### DIFF
--- a/pr_io.py
+++ b/pr_io.py
@@ -31,7 +31,8 @@ def deobfuscateFile(file_name, omit_first_bytes):
         enc_bytes.append(0)
     enc_bytes = getCipher().decrypt(bytes(enc_bytes))
     data = inflate(enc_bytes)
-    print(data)
+    text = data.decode("utf-8") # this way we actually output real utf-8, instead of the raw binary bits. This saves us all the by hand cleanup.
+    print(text)
 
 def deflate(data):
     compress = zlib.compressobj(-1, zlib.DEFLATED, -15)

--- a/pr_io.py
+++ b/pr_io.py
@@ -32,6 +32,9 @@ def deobfuscateFile(file_name, omit_first_bytes):
     enc_bytes = getCipher().decrypt(bytes(enc_bytes))
     data = inflate(enc_bytes)
     text = data.decode("utf-8") # this way we actually output real utf-8, instead of the raw binary bits. This saves us all the by hand cleanup.
+    file = open("temp.txt", "w", encoding="utf8")  # we can write a temp.txt file in case the console being used isn't in utf8 mode (more common than you think)
+    file.write(text)
+    file.close()
     print(text)
 
 def deflate(data):


### PR DESCRIPTION
This change makes supporting non-latin/ASCII languages much more straight forward by not requiring hand processing binary->UTF8 conversion by the consuming application. It may break existing users who already do this conversion though.